### PR TITLE
Add Support for compiling with MSVC and some error handling

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,39 @@
+@rem Turn off echoing of commands.
+@echo off
+
+rem Make sure local variables don't spill into the global environment.
+setlocal EnableExtensions
+
+rem Make sure we're in the src directory.
+pushd "%~dp0src"
+
+rem Treat the first parameter to this batch script as a target.
+set target=%1
+
+rem If a target is specified, call the subroutine
+if "%target%"=="" (call :build) else (call :%target%)
+goto :end
+
+
+:build
+  rem Compiler flags:
+  rem   /nologo Don't print tedious MS logo stuff in the beginning
+  rem   /DEBUG  Compile in debug mode.
+  rem   /Z7     Create debug symbols as .pdb files
+  rem   /TC     Compile as C, not C++
+  set CFLAGS=/nologo /DEBUG /Z7 /TC
+
+  rem Compile the sources.
+  cl %CFLAGS% main.c cpu.c gfx.c interconnect.c util.c
+exit /B
+
+
+:clean
+  rem Delete all intermediate files.
+  del *.obj *.exe *.o *.a *.lib *.pdb *.ilk
+exit /B
+
+
+:end
+rem Restore previous directory.
+popd

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,11 @@
 #include "cpu.h"
 
 int main(int argc, const char* argv[]){
+    if(argc != 2) {
+        fprintf(stderr, "Missing first argument (the rom to load).\n");
+        return 1;
+    }
+
     uint64_t fileLen = 0;
     unsigned char* rom = NULL;
     read_from_disk(argv[1], &fileLen, &rom);


### PR DESCRIPTION
I've added a `make.bat` file that behaves roughly like regular make for this case.

``` bash
$ make # compiles main.exe
$ make build # same as above.
$ make clean # deletes intermediate files
```

I've also added a check in the `main()` function to tell the user when the `rom` argument is missing. 😄 

And yes, I did it for teh lulz. 😄 Feel free to reject this PR 😂 
